### PR TITLE
feat: add ability to specify which apps are visible to a user

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -17,12 +17,16 @@ Manage users in the Apple Developer Program using the App Store Connect API.
 
 ### Required
 
-- `all_apps_visible` (Boolean) Whether the user can see all apps
 - `email` (String) User's email address
 - `first_name` (String) User's first name
 - `last_name` (String) User's last name
 - `provisioning_allowed` (Boolean) Whether the user is allowed to create new provisioning profiles
 - `roles` (Set of String) User's roles in the Apple Developer Program
+
+### Optional
+
+- `all_apps_visible` (Boolean) Whether the user can see all apps
+- `visible_apps` (Set of String) A list of IDs for the apps that the user has permission to see
 
 ### Read-Only
 

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/oliver-binns/appstore-go v0.0.0-20250630201404-d5bdc2bf34b1
+	github.com/oliver-binns/appstore-go v0.0.0-20250702200953-a16502273eda
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,10 @@ github.com/oliver-binns/appstore-go v0.0.0-20250630190823-da3cdb21c3f4 h1:2g3nuq
 github.com/oliver-binns/appstore-go v0.0.0-20250630190823-da3cdb21c3f4/go.mod h1:RgHQqeRyFKqR8/EUeJNcB4yJi3L5WVSAMWzSTvXPnrg=
 github.com/oliver-binns/appstore-go v0.0.0-20250630201404-d5bdc2bf34b1 h1:HFZuI/s5L7SxZ/DOhguf/L4ihYducNhuImVT5Rrt+gM=
 github.com/oliver-binns/appstore-go v0.0.0-20250630201404-d5bdc2bf34b1/go.mod h1:RgHQqeRyFKqR8/EUeJNcB4yJi3L5WVSAMWzSTvXPnrg=
+github.com/oliver-binns/appstore-go v0.0.0-20250702182524-d16f5cca337d h1:48kItwubVowygC/I/d4l8BHDuFX06urEvvBm8lxTIzQ=
+github.com/oliver-binns/appstore-go v0.0.0-20250702182524-d16f5cca337d/go.mod h1:RgHQqeRyFKqR8/EUeJNcB4yJi3L5WVSAMWzSTvXPnrg=
+github.com/oliver-binns/appstore-go v0.0.0-20250702200953-a16502273eda h1:73VvWaLz8BmcoNe2lq2D+Vx+IisIV5YcsC5sNXi5WNs=
+github.com/oliver-binns/appstore-go v0.0.0-20250702200953-a16502273eda/go.mod h1:RgHQqeRyFKqR8/EUeJNcB4yJi3L5WVSAMWzSTvXPnrg=
 github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75 h1:VA4I9YBHeXFvwrrayDnGizSR26KoUmZw4rbUveyNq2k=
 github.com/oliver-binns/googleplay-go v0.0.0-20250628102308-9551b2040f75/go.mod h1:JUBt/rWkAOkR9qSxKVH4Iid37RrExqIQheP5MVXLy/Y=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=


### PR DESCRIPTION
```hcl
resource "appstoreconnect_user" "test" {
  first_name = "John"
  last_name  = "Smith"

  email = "test@example.com"
  roles = ["DEVELOPER"]

  all_apps_visible     = false
  visible_apps         = ["1598625719"]
  provisioning_allowed = false
}
```