### PR TITLE
fix: resolve issue where visible_apps would conflict with all_apps_visible even when not provided

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -130,7 +130,7 @@ func (r UserResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 	}
 
 	// If the user can view all apps, the list of apps must not be set
-	if data.AllAppsVisible.ValueBool() && !data.VisibleApps.IsUnknown() {
+	if data.AllAppsVisible.ValueBool() && !data.VisibleApps.IsNull() {
 		resp.Diagnostics.AddAttributeError(
 			path.Root("visible_apps"),
 			"Invalid Configuration",


### PR DESCRIPTION
resolve issue where visible_apps would conflict with all_apps_visible even when not provided

```
╷
│ Error: Invalid Configuration
│ 
│   with appstoreconnect_user.admins,
│   on app-store.tf line 12, in resource "appstoreconnect_user" "admins":
│   12: resource "appstoreconnect_user" "admins" {
│ 
│ If `all_apps_visible` is set to true, the list of visible apps must not be provided.
```