### PR TITLE
fix: update commit name workflow to use macos-26 runner

### DIFF
--- a/.github/workflows/commit-name.yml
+++ b/.github/workflows/commit-name.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     name: Validate Pull Request
     if: github.event.pull_request.draft == false
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - name: Add Path Globally


### PR DESCRIPTION
## Summary

- Updates the `Enforce Commit Name` workflow runner from `macos-15` to `macos-26`

The `macos-15` runner ships with Swift 6.1, but `Package.swift` in `Oliver-Binns/Versioning` requires Swift 6.2, causing the workflow to fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)