### PR TITLE
fix: update release workflow to use macos-26 runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   determine_increment:
     name: Create GitHub tag
-    runs-on: macos-15
+    runs-on: macos-26
     outputs:
       should_release: ${{ steps.versioning.outputs.release_version }}
 


### PR DESCRIPTION
## Summary

Updates the `Create release` workflow runner from `macos-15` to `macos-26`.

The `macos-15` runner ships with Swift 6.1, but `Package.swift` in `Oliver-Binns/Versioning` requires Swift 6.2, causing the release workflow to fail on every push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)