### PR TITLE
fix: prevent nil pointer panic in Read when GetUser returns an error

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -24,13 +24,21 @@ import (
 var _ resource.Resource = &UserResource{}
 var _ resource.ResourceWithImportState = &UserResource{}
 
+type userClient interface {
+	GetUser(ctx context.Context, id string) (*users.User, error)
+	CreateUser(ctx context.Context, user users.User) (*users.User, error)
+	ModifyUser(ctx context.Context, id string, user users.User) (*users.User, error)
+	DeleteUser(ctx context.Context, id string) error
+	FindUserByEmail(ctx context.Context, email string) (*users.User, error)
+}
+
 func NewUserResource() resource.Resource {
 	return &UserResource{}
 }
 
 // UserResource defines the resource implementation.
 type UserResource struct {
-	client *appstore.Client
+	client userClient
 }
 
 // UserResourceModel describes the resource data model.
@@ -237,6 +245,10 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	user, err := r.client.GetUser(ctx, data.ID.ValueString())
+	if err != nil {
+		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
+		return
+	}
 
 	data.ID = types.StringValue(user.ID)
 	data.FirstName = types.StringValue(user.FirstName)
@@ -252,11 +264,6 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
 	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)
-
-	if err != nil {
-		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
-		return
-	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package provider
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/oliver-binns/appstore-go/users"
+)
+
+type mockUserClient struct {
+	getUserFn func(ctx context.Context, id string) (*users.User, error)
+}
+
+func (m *mockUserClient) GetUser(ctx context.Context, id string) (*users.User, error) {
+	return m.getUserFn(ctx, id)
+}
+
+func (m *mockUserClient) CreateUser(ctx context.Context, user users.User) (*users.User, error) {
+	return nil, nil
+}
+
+func (m *mockUserClient) ModifyUser(ctx context.Context, id string, user users.User) (*users.User, error) {
+	return nil, nil
+}
+
+func (m *mockUserClient) DeleteUser(ctx context.Context, id string) error {
+	return nil
+}
+
+func (m *mockUserClient) FindUserByEmail(ctx context.Context, email string) (*users.User, error) {
+	return nil, nil
+}
+
+func TestUserResource_Read_ReturnsErrorWithoutPanic(t *testing.T) {
+	r := &UserResource{
+		client: &mockUserClient{
+			getUserFn: func(ctx context.Context, id string) (*users.User, error) {
+				return nil, errors.New("API unavailable")
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	stateVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, "some-uuid"),
+		"first_name":           tftypes.NewValue(tftypes.String, nil),
+		"last_name":            tftypes.NewValue(tftypes.String, nil),
+		"email":                tftypes.NewValue(tftypes.String, nil),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, nil),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{
+			Schema: schema,
+			Raw:    stateVal,
+		},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{
+			Schema: schema,
+			Raw:    stateVal,
+		},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if !resp.Diagnostics.HasError() {
+		t.Fatal("expected error diagnostic, got none")
+	}
+	if resp.Diagnostics.Errors()[0].Summary() != "Client Error" {
+		t.Fatalf("unexpected error summary: %s", resp.Diagnostics.Errors()[0].Summary())
+	}
+}
+
+func userResourceSchema() schema.Schema {
+	r := &UserResource{}
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
+	return schemaResp.Schema
+}


### PR DESCRIPTION
## Summary

- Fixes a nil pointer dereference panic in \`Read\` where \`user\` was dereferenced before checking the error returned by \`GetUser\`
- Introduces a \`userClient\` interface so the client can be mocked in unit tests
- Adds \`TestUserResource_Read_ReturnsErrorWithoutPanic\` which panics without the fix and passes with it

This bug was surfaced when Terraform tried to read a newly imported user and the API returned an error — previously causing a provider crash rather than a clean diagnostic.

## Test plan

- [x] \`TestUserResource_Read_ReturnsErrorWithoutPanic\` — panics on unfixed code, passes with fix
- [x] \`go build ./...\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)