### PR TITLE
fix: set visible_apps to null when all_apps_visible is true

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/oliver-binns/appstore-go v0.0.0-20260427140659-0dc43070234a
+	github.com/oliver-binns/appstore-go v0.12.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oliver-binns/appstore-go v0.0.0-20260427140659-0dc43070234a h1:n3ijHY0zyPXF1MjUsxWDnP3M9KJgiAHOF8MUEPaBunE=
-github.com/oliver-binns/appstore-go v0.0.0-20260427140659-0dc43070234a/go.mod h1:56woJXGdcIh0cByRgzM95X8WZkBrfNWt/czIRfZHfrA=
+github.com/oliver-binns/appstore-go v0.12.1 h1:O+DlWD2Av+nEvUHWozbAoyHyJXz45XplAL4EngtMef0=
+github.com/oliver-binns/appstore-go v0.12.1/go.mod h1:56woJXGdcIh0cByRgzM95X8WZkBrfNWt/czIRfZHfrA=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -224,8 +224,12 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 	data.Roles, diag = types.SetValueFrom(ctx, types.StringType, user.Roles)
 	resp.Diagnostics.Append(diag...)
 
-	data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	resp.Diagnostics.Append(diag...)
+	if user.AllAppsVisible {
+		data.VisibleApps = types.SetNull(types.StringType)
+	} else {
+		data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
+		resp.Diagnostics.Append(diag...)
+	}
 
 	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
 	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)
@@ -259,8 +263,12 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	data.Roles = roles
 	resp.Diagnostics.Append(diag...)
 
-	data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	resp.Diagnostics.Append(diag...)
+	if user.AllAppsVisible {
+		data.VisibleApps = types.SetNull(types.StringType)
+	} else {
+		data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
+		resp.Diagnostics.Append(diag...)
+	}
 
 	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
 	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)
@@ -312,8 +320,12 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	data.Roles, diag = types.SetValueFrom(ctx, types.StringType, user.Roles)
 	resp.Diagnostics.Append(diag...)
 
-	data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	resp.Diagnostics.Append(diag...)
+	if user.AllAppsVisible {
+		data.VisibleApps = types.SetNull(types.StringType)
+	} else {
+		data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
+		resp.Diagnostics.Append(diag...)
+	}
 
 	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
 	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)

--- a/internal/provider/user_resource_test.go
+++ b/internal/provider/user_resource_test.go
@@ -155,7 +155,49 @@ func TestAccUserResource(t *testing.T) {
 	})
 }
 
-func testAccUserResourceConfig(accountEmail string, role string, all_apps_visible bool, app_visible string) string {
+func TestAccUserResource_AllAppsVisible(t *testing.T) {
+	accountEmail := fmt.Sprintf(
+		"%s@oliverbinns.co.uk",
+		uuid.New().String(),
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create with all_apps_visible = true
+			{
+				Config: testAccUserResourceConfig(accountEmail, "MARKETING", true, ""),
+				ConfigStateChecks: []statecheck.StateCheck{
+					statecheck.ExpectKnownValue(
+						"appstoreconnect_user.test",
+						tfjsonpath.New("all_apps_visible"),
+						knownvalue.Bool(true),
+					),
+					statecheck.ExpectKnownValue(
+						"appstoreconnect_user.test",
+						tfjsonpath.New("visible_apps"),
+						knownvalue.Null(),
+					),
+				},
+			},
+			// Import should not produce a diff against config with visible_apps = null
+			{
+				ResourceName:      "appstoreconnect_user.test",
+				ImportState:       true,
+				ImportStateId:     accountEmail,
+				ImportStateVerify: true,
+			},
+			// Delete testing automatically occurs in TestCase
+		},
+	})
+}
+
+func testAccUserResourceConfig(accountEmail string, role string, allAppsVisible bool, appVisible string) string {
+	visibleAppsLine := ""
+	if !allAppsVisible {
+		visibleAppsLine = fmt.Sprintf("  visible_apps = [%s]", appVisible)
+	}
 	return fmt.Sprintf(`
 resource "appstoreconnect_user" "test" {
   first_name = "John"
@@ -165,23 +207,23 @@ resource "appstoreconnect_user" "test" {
   roles = ["%s"]
 
   all_apps_visible     = %t
-  visible_apps         = [%s]
+%s
   provisioning_allowed = false
 }
 
 variable "issuer_id" {
-  type        = string
-  sensitive   = true
+  type      = string
+  sensitive = true
 }
 
 variable "key_id" {
-  type        = string
-  sensitive   = true
+  type      = string
+  sensitive = true
 }
 
 variable "private_key" {
-  type        = string
-  sensitive   = true
+  type      = string
+  sensitive = true
 }
 
 provider "appstoreconnect" {
@@ -189,5 +231,5 @@ provider "appstoreconnect" {
   key_id      = var.key_id
   private_key = var.private_key
 }
-`, accountEmail, role, all_apps_visible, app_visible)
+`, accountEmail, role, allAppsVisible, visibleAppsLine)
 }

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -83,6 +83,57 @@ func TestUserResource_Read_ReturnsErrorWithoutPanic(t *testing.T) {
 	}
 }
 
+func TestUserResource_Read_SetsVisibleAppsNullWhenAllAppsVisible(t *testing.T) {
+	r := &UserResource{
+		client: &mockUserClient{
+			getUserFn: func(ctx context.Context, id string) (*users.User, error) {
+				return &users.User{
+					ID:                  "some-uuid",
+					FirstName:           "Oliver",
+					LastName:            "Binns",
+					Username:            "obinns@example.com",
+					Roles:               []users.UserRole{users.Admin},
+					AllAppsVisible:      true,
+					ProvisioningAllowed: true,
+					VisibleAppIDs:       []string{},
+				}, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	stateVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, "some-uuid"),
+		"first_name":           tftypes.NewValue(tftypes.String, nil),
+		"last_name":            tftypes.NewValue(tftypes.String, nil),
+		"email":                tftypes.NewValue(tftypes.String, nil),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, nil),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Summary())
+	}
+
+	var data UserResourceModel
+	resp.State.Get(context.Background(), &data)
+
+	if !data.VisibleApps.IsNull() {
+		t.Fatalf("expected visible_apps to be null when all_apps_visible is true, got %s", data.VisibleApps)
+	}
+}
+
 func userResourceSchema() schema.Schema {
 	r := &UserResource{}
 	schemaResp := &resource.SchemaResponse{}


### PR DESCRIPTION
## Summary

- When `all_apps_visible = true`, the App Store Connect API returns no `visibleApps` relationship. The provider was storing this as an empty set (`[]`) rather than null, causing a spurious diff against the Terraform config which correctly uses `null` for this case.
- This spurious diff triggered an unnecessary `Modify` call after import, which failed silently — `modify.go` in appstore-go had no status code check, so a non-200 response was decoded as a zero-value `User` struct and returned without error, causing Terraform to report "Provider produced inconsistent result after apply".
- Both bugs are now fixed: the status code check in appstore-go (released as v0.12.1), and the null handling in the provider.

## Test plan

- [x] Import an existing user via email — plan should show no unexpected updates after import
- [x] Verify CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)