### PR TITLE
chore(deps): bump appstore-go to v0.12.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.28.0
 	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/hashicorp/terraform-plugin-testing v1.13.2
-	github.com/oliver-binns/appstore-go v0.0.0-20260427140659-0dc43070234a
+	github.com/oliver-binns/appstore-go v0.12.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
-github.com/oliver-binns/appstore-go v0.0.0-20260427140659-0dc43070234a h1:n3ijHY0zyPXF1MjUsxWDnP3M9KJgiAHOF8MUEPaBunE=
-github.com/oliver-binns/appstore-go v0.0.0-20260427140659-0dc43070234a/go.mod h1:56woJXGdcIh0cByRgzM95X8WZkBrfNWt/czIRfZHfrA=
+github.com/oliver-binns/appstore-go v0.12.1 h1:O+DlWD2Av+nEvUHWozbAoyHyJXz45XplAL4EngtMef0=
+github.com/oliver-binns/appstore-go v0.12.1/go.mod h1:56woJXGdcIh0cByRgzM95X8WZkBrfNWt/czIRfZHfrA=
 github.com/pjbgf/sha1cd v0.3.2 h1:a9wb0bp1oC2TGwStyn0Umc/IGKQnEgF0vVaZ8QF8eo4=
 github.com/pjbgf/sha1cd v0.3.2/go.mod h1:zQWigSxVmsHEZow5qaLtPYxpcKMMQpa09ixqBxuCS6A=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## Summary

- Bumps `github.com/oliver-binns/appstore-go` from the pseudo-version `v0.0.0-20260427140659-0dc43070234a` to the tagged release `v0.12.1`
- v0.12.1 includes the fix to check the HTTP status code in `Modify` before decoding the response body

## Test plan

- [x] CI acceptance tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)