### PR TITLE
build: trigger release after appstore-go dependency bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.5.2
+
+DEPENDENCIES:
+
+* bump `github.com/oliver-binns/appstore-go` to v0.12.1
+
 ## 0.1.0 (Unreleased)
 
 FEATURES:


### PR DESCRIPTION
Empty commit to trigger a patch version release following the appstore-go v0.12.1 dependency bump in #26, which used a `chore:` prefix and didn't trigger versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)