### PR TITLE
fix: fall back to email lookup in Read when user ID is missing from state

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
@@ -244,29 +245,48 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 		return
 	}
 
+	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		user, err := r.client.FindUserByEmail(ctx, data.Email.ValueString())
+		if err != nil {
+			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to find user by email, got error: %s", err))
+			return
+		}
+		if user == nil {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		r.populateState(ctx, &data, user, resp.Diagnostics)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+		return
+	}
+
 	user, err := r.client.GetUser(ctx, data.ID.ValueString())
 	if err != nil {
 		resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to read user, got error: %s", err))
 		return
 	}
 
+	r.populateState(ctx, &data, user, resp.Diagnostics)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *UserResource) populateState(ctx context.Context, data *UserResourceModel, user *users.User, diags diag.Diagnostics) {
 	data.ID = types.StringValue(user.ID)
 	data.FirstName = types.StringValue(user.FirstName)
 	data.LastName = types.StringValue(user.LastName)
 	data.Email = types.StringValue(user.Username)
 
-	roles, diag := types.SetValueFrom(ctx, types.StringType, user.Roles)
-	data.Roles = roles
-	resp.Diagnostics.Append(diag...)
+	var d diag.Diagnostics
+	data.Roles, d = types.SetValueFrom(ctx, types.StringType, user.Roles)
+	diags.Append(d...)
 
-	data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	resp.Diagnostics.Append(diag...)
+	data.VisibleApps, d = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
+	diags.Append(d...)
 
 	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
 	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)
-
-	// Save updated data into Terraform state
-	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 type mockUserClient struct {
-	getUserFn func(ctx context.Context, id string) (*users.User, error)
+	getUserFn         func(ctx context.Context, id string) (*users.User, error)
+	findUserByEmailFn func(ctx context.Context, email string) (*users.User, error)
 }
 
 func (m *mockUserClient) GetUser(ctx context.Context, id string) (*users.User, error) {
@@ -36,6 +37,9 @@ func (m *mockUserClient) DeleteUser(ctx context.Context, id string) error {
 }
 
 func (m *mockUserClient) FindUserByEmail(ctx context.Context, email string) (*users.User, error) {
+	if m.findUserByEmailFn != nil {
+		return m.findUserByEmailFn(ctx, email)
+	}
 	return nil, nil
 }
 
@@ -80,6 +84,98 @@ func TestUserResource_Read_ReturnsErrorWithoutPanic(t *testing.T) {
 	}
 	if resp.Diagnostics.Errors()[0].Summary() != "Client Error" {
 		t.Fatalf("unexpected error summary: %s", resp.Diagnostics.Errors()[0].Summary())
+	}
+}
+
+func TestUserResource_Read_FallsBackToEmailLookup_WhenIDIsEmpty(t *testing.T) {
+	findCalled := false
+	r := &UserResource{
+		client: &mockUserClient{
+			getUserFn: func(ctx context.Context, id string) (*users.User, error) {
+				t.Fatal("GetUser should not be called when ID is empty")
+				return nil, nil
+			},
+			findUserByEmailFn: func(ctx context.Context, email string) (*users.User, error) {
+				findCalled = true
+				return &users.User{
+					ID:        "found-uuid",
+					FirstName: "John",
+					LastName:  "Smith",
+					Username:  email,
+					Roles:     []users.UserRole{"DEVELOPER"},
+				}, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	stateVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, ""),
+		"first_name":           tftypes.NewValue(tftypes.String, nil),
+		"last_name":            tftypes.NewValue(tftypes.String, nil),
+		"email":                tftypes.NewValue(tftypes.String, "john@example.com"),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, nil),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+	}
+	if !findCalled {
+		t.Fatal("expected FindUserByEmail to be called, but it was not")
+	}
+}
+
+func TestUserResource_Read_RemovesFromState_WhenIDIsEmptyAndUserNotFound(t *testing.T) {
+	r := &UserResource{
+		client: &mockUserClient{
+			getUserFn: func(ctx context.Context, id string) (*users.User, error) {
+				t.Fatal("GetUser should not be called when ID is empty")
+				return nil, nil
+			},
+			findUserByEmailFn: func(ctx context.Context, email string) (*users.User, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	stateVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, ""),
+		"first_name":           tftypes.NewValue(tftypes.String, nil),
+		"last_name":            tftypes.NewValue(tftypes.String, nil),
+		"email":                tftypes.NewValue(tftypes.String, "john@example.com"),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, nil),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatal("expected resource to be removed from state, but state is not null")
 	}
 }
 


### PR DESCRIPTION
## Summary

- When the user ID is null or empty in Terraform state (e.g. from a partial/failed apply), `GetUser` was being called with an empty string, which silently hit the list endpoint `GET /v1/users` and returned `data` as a JSON array — causing a confusing unmarshal error
- This change falls back to `FindUserByEmail` to recover the resource gracefully without requiring manual re-import
- If the user can't be found by email either, the resource is removed from state so Terraform will plan a re-create
- Extracts a `populateState` helper to avoid duplicating state-mapping logic

## Test plan

- [x] `TestUserResource_Read_FallsBackToEmailLookup_WhenIDIsEmpty` — verifies `GetUser` is never called with an empty ID and the email lookup recovers the resource
- [x] `TestUserResource_Read_RemovesFromState_WhenIDIsEmptyAndUserNotFound` — verifies the resource is cleanly removed from state when the user can't be found by email

🤖 Generated with [Claude Code](https://claude.com/claude-code)