### PR TITLE
fix: remove corrupted state entry when both ID and email are empty

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -246,6 +246,10 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 	}
 
 	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
+		if data.Email.IsNull() || data.Email.IsUnknown() || data.Email.ValueString() == "" {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		user, err := r.client.FindUserByEmail(ctx, data.Email.ValueString())
 		if err != nil {
 			resp.Diagnostics.AddError("Client Error", fmt.Sprintf("Unable to find user by email, got error: %s", err))

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -247,6 +247,7 @@ func (r *UserResource) Read(ctx context.Context, req resource.ReadRequest, resp 
 
 	if data.ID.IsNull() || data.ID.IsUnknown() || data.ID.ValueString() == "" {
 		if data.Email.IsNull() || data.Email.IsUnknown() || data.Email.ValueString() == "" {
+			tflog.Warn(ctx, "User resource has no ID or email in state, removing from state to allow re-import")
 			resp.State.RemoveResource(ctx)
 			return
 		}

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -179,6 +179,49 @@ func TestUserResource_Read_RemovesFromState_WhenIDIsEmptyAndUserNotFound(t *test
 	}
 }
 
+func TestUserResource_Read_RemovesFromState_WhenIDAndEmailAreEmpty(t *testing.T) {
+	r := &UserResource{
+		client: &mockUserClient{
+			getUserFn: func(ctx context.Context, id string) (*users.User, error) {
+				t.Fatal("GetUser should not be called when ID is empty")
+				return nil, nil
+			},
+			findUserByEmailFn: func(ctx context.Context, email string) (*users.User, error) {
+				t.Fatal("FindUserByEmail should not be called when email is empty")
+				return nil, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	stateVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, ""),
+		"first_name":           tftypes.NewValue(tftypes.String, nil),
+		"last_name":            tftypes.NewValue(tftypes.String, nil),
+		"email":                tftypes.NewValue(tftypes.String, ""),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, nil),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, nil),
+	})
+
+	req := resource.ReadRequest{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+	resp := &resource.ReadResponse{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+
+	r.Read(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+	}
+	if !resp.State.Raw.IsNull() {
+		t.Fatal("expected resource to be removed from state, but state is not null")
+	}
+}
+
 func userResourceSchema() schema.Schema {
 	r := &UserResource{}
 	schemaResp := &resource.SchemaResponse{}


### PR DESCRIPTION
## Summary

- When a user resource exists in Terraform state with both `id` and `email` empty (caused by an import being attempted before email-based import was supported), `Read` was calling `FindUserByEmail("")`, which returns HTTP 400 from the App Store Connect API
- This fix detects the empty-email case and calls `RemoveResource` instead, allowing Terraform to re-run the `import` block cleanly on the next plan

## Root cause

The `import` blocks in mobile-infra use email addresses as import IDs. These blocks ran in CI before the email-based `ImportState` support was in place, leaving the user resources in Terraform Cloud state with empty `id` and `email` fields. On subsequent plans, `Read` fell through to the email fallback and called `FindUserByEmail("")` → 400.

## Self-healing behaviour

With this fix, the next plan will:
1. Call `Read` → detects empty ID + empty email → removes resource from state (no 400)
2. See the `import` block → calls `ImportState(email)` → `FindUserByEmail` succeeds → UUID stored
3. Call `Read` with UUID → `GetUser` succeeds → state fully populated

No manual state surgery required.

## Test plan

- [x] `TestUserResource_Read_RemovesFromState_WhenIDAndEmailAreEmpty` — asserts neither `GetUser` nor `FindUserByEmail` is called, and the resource is removed from state

🤖 Generated with [Claude Code](https://claude.com/claude-code)