### PR TITLE
fix: exclude read-only fields from ModifyUser PATCH request

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -313,9 +313,6 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 	resp.Diagnostics.Append(diag...)
 
 	user, err := r.client.ModifyUser(ctx, data.ID.ValueString(), users.User{
-		FirstName:           data.FirstName.ValueString(),
-		LastName:            data.LastName.ValueString(),
-		Username:            data.Email.ValueString(),
 		Roles:               roles,
 		AllAppsVisible:      data.AllAppsVisible.ValueBool(),
 		VisibleAppIDs:       appIDs,

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -17,6 +17,7 @@ import (
 
 type mockUserClient struct {
 	getUserFn         func(ctx context.Context, id string) (*users.User, error)
+	modifyUserFn      func(ctx context.Context, id string, user users.User) (*users.User, error)
 	findUserByEmailFn func(ctx context.Context, email string) (*users.User, error)
 }
 
@@ -29,7 +30,10 @@ func (m *mockUserClient) CreateUser(ctx context.Context, user users.User) (*user
 }
 
 func (m *mockUserClient) ModifyUser(ctx context.Context, id string, user users.User) (*users.User, error) {
-	return nil, nil
+	if m.modifyUserFn != nil {
+		return m.modifyUserFn(ctx, id, user)
+	}
+	return &users.User{}, nil
 }
 
 func (m *mockUserClient) DeleteUser(ctx context.Context, id string) error {
@@ -227,4 +231,55 @@ func userResourceSchema() schema.Schema {
 	schemaResp := &resource.SchemaResponse{}
 	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
 	return schemaResp.Schema
+}
+
+func TestUserResource_Update_DoesNotSendReadOnlyFields(t *testing.T) {
+	var capturedUser users.User
+
+	r := &UserResource{
+		client: &mockUserClient{
+			getUserFn: func(ctx context.Context, id string) (*users.User, error) {
+				return &users.User{HasAcceptedInvite: true}, nil
+			},
+			modifyUserFn: func(ctx context.Context, id string, user users.User) (*users.User, error) {
+				capturedUser = user
+				return &users.User{}, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	stateVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, "some-uuid"),
+		"first_name":           tftypes.NewValue(tftypes.String, "John"),
+		"last_name":            tftypes.NewValue(tftypes.String, "Smith"),
+		"email":                tftypes.NewValue(tftypes.String, "jsmith@example.com"),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{tftypes.NewValue(tftypes.String, "DEVELOPER")}),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, false),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{}),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, true),
+	})
+
+	req := resource.UpdateRequest{
+		Plan:  tfsdk.Plan{Schema: schema, Raw: stateVal},
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+	resp := &resource.UpdateResponse{
+		State: tfsdk.State{Schema: schema, Raw: stateVal},
+	}
+
+	r.Update(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+	}
+	if capturedUser.FirstName != "" {
+		t.Errorf("expected FirstName to be empty in ModifyUser call, got %q", capturedUser.FirstName)
+	}
+	if capturedUser.LastName != "" {
+		t.Errorf("expected LastName to be empty in ModifyUser call, got %q", capturedUser.LastName)
+	}
+	if capturedUser.Username != "" {
+		t.Errorf("expected Username to be empty in ModifyUser call, got %q", capturedUser.Username)
+	}
 }


### PR DESCRIPTION
## Problem

The `Update` function was passing `first_name`, `last_name`, and `email` to the `ModifyUser` PATCH call. The [App Store Connect API](https://developer.apple.com/documentation/appstoreconnectapi/userupdaterequest/data-data.dictionary/attributes-data.dictionary) does not include these fields in `UserUpdateRequest.Attributes` — only `allAppsVisible`, `provisioningAllowed`, and `roles` are accepted.

For personal Apple ID users the API silently ignores the extra fields, but for **managed Apple ID users** (provisioned via Apple Business Manager) the API returns `405 Method Not Allowed`, causing Terraform applies to fail whenever any other attribute (e.g. `roles`) needed updating.

## Fix

Remove `FirstName`, `LastName`, and `Username` from the `users.User` passed to `ModifyUser`. These fields already have `RequiresReplace()` plan modifiers, so they can never change in an in-place update anyway — the `omitempty` tags on the Go struct mean passing empty strings is sufficient to omit them from the request body.

## Tests

Added a unit test (`TestUserResource_Update_DoesNotSendReadOnlyFields`) that captures the `users.User` passed to `ModifyUser` and asserts `FirstName`, `LastName`, and `Username` are empty. The existing integration test didn't catch this because it uses a personal Apple ID account, which tolerates the extra fields.