### PR TITLE
fix: preserve id across updates with UseStateForUnknown

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -67,6 +67,9 @@ func (r *UserResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 			"id": schema.StringAttribute{
 				Computed:            true,
 				MarkdownDescription: "User identifier",
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
 			},
 			"first_name": schema.StringAttribute{
 				MarkdownDescription: "User's first name",


### PR DESCRIPTION
## Problem

Without `UseStateForUnknown()` on the `id` attribute, Terraform marks it as `(known after apply)` in the plan during updates — as seen in the mobile-infra build:

```
~ id = "69a495ca-e25e-5733-e053-5b8c7c1155b0" -> (known after apply)
```

This means `data.ID` is empty when `ModifyUser` is called, resulting in a PATCH to `/v1/users/` (no ID) which the API rejects with 405.

## Fix

Add `stringplanmodifier.UseStateForUnknown()` to the `id` attribute so Terraform carries the existing value forward from state into the plan during updates.