### PR TITLE
fix: set visible_apps to null in state when all_apps_visible is true

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -290,8 +290,12 @@ func (r *UserResource) populateState(ctx context.Context, data *UserResourceMode
 	data.Roles, d = types.SetValueFrom(ctx, types.StringType, user.Roles)
 	diags.Append(d...)
 
-	data.VisibleApps, d = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	diags.Append(d...)
+	if user.AllAppsVisible {
+		data.VisibleApps = types.SetNull(types.StringType)
+	} else {
+		data.VisibleApps, d = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
+		diags.Append(d...)
+	}
 
 	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
 	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
@@ -231,6 +232,44 @@ func userResourceSchema() schema.Schema {
 	schemaResp := &resource.SchemaResponse{}
 	r.Schema(context.Background(), resource.SchemaRequest{}, schemaResp)
 	return schemaResp.Schema
+}
+
+func TestPopulateState_SetsVisibleAppsNullWhenAllAppsVisible(t *testing.T) {
+	r := &UserResource{}
+	data := &UserResourceModel{}
+	var diags diag.Diagnostics
+
+	user := &users.User{
+		AllAppsVisible: true,
+		VisibleAppIDs:  []string{"111", "222"},
+	}
+
+	r.populateState(context.Background(), data, user, diags)
+
+	if !data.VisibleApps.IsNull() {
+		t.Errorf("expected VisibleApps to be null when AllAppsVisible is true, got %v", data.VisibleApps)
+	}
+}
+
+func TestPopulateState_SetsVisibleAppsFromAPIWhenNotAllAppsVisible(t *testing.T) {
+	r := &UserResource{}
+	data := &UserResourceModel{}
+	var diags diag.Diagnostics
+
+	user := &users.User{
+		AllAppsVisible: false,
+		VisibleAppIDs:  []string{"111", "222"},
+	}
+
+	r.populateState(context.Background(), data, user, diags)
+
+	if data.VisibleApps.IsNull() {
+		t.Error("expected VisibleApps to be populated when AllAppsVisible is false")
+	}
+	elements := data.VisibleApps.Elements()
+	if len(elements) != 2 {
+		t.Errorf("expected 2 visible app IDs, got %d", len(elements))
+	}
 }
 
 func TestUserResource_Update_DoesNotSendReadOnlyFields(t *testing.T) {


### PR DESCRIPTION
## Problem

When `all_apps_visible = true`, the Terraform config sets `visible_apps = null`. However `populateState` was always populating `VisibleApps` from the API response, causing a perpetual diff on every plan and a spurious Update call.

## Fix

In `populateState`, when `user.AllAppsVisible == true`, set `data.VisibleApps = types.SetNull(types.StringType)` instead of populating from the API response.

## Tests

Added two unit tests for `populateState`:
- `TestPopulateState_SetsVisibleAppsNullWhenAllAppsVisible`
- `TestPopulateState_SetsVisibleAppsFromAPIWhenNotAllAppsVisible`

Note: `ValidateConfig` already returns an error if a consumer sets both `visible_apps` and `all_apps_visible = true`, so there is no ambiguity about intent.