### PR TITLE
ci: fix Update not setting VisibleApps to null when AllAppsVisible is true

### DIFF
--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -333,19 +333,7 @@ func (r *UserResource) Update(ctx context.Context, req resource.UpdateRequest, r
 
 	tflog.Trace(ctx, "modified a user")
 
-	data.ID = types.StringValue(user.ID)
-	data.FirstName = types.StringValue(user.FirstName)
-	data.LastName = types.StringValue(user.LastName)
-	data.Email = types.StringValue(user.Username)
-
-	data.Roles, diag = types.SetValueFrom(ctx, types.StringType, user.Roles)
-	resp.Diagnostics.Append(diag...)
-
-	data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	resp.Diagnostics.Append(diag...)
-
-	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
-	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)
+	r.populateState(ctx, &data, user, resp.Diagnostics)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -272,6 +272,53 @@ func TestPopulateState_SetsVisibleAppsFromAPIWhenNotAllAppsVisible(t *testing.T)
 	}
 }
 
+func TestUserResource_Update_SetsVisibleAppsNullWhenAllAppsVisible(t *testing.T) {
+	r := &UserResource{
+		client: &mockUserClient{
+			modifyUserFn: func(ctx context.Context, id string, user users.User) (*users.User, error) {
+				return &users.User{
+					ID:             "some-uuid",
+					AllAppsVisible: true,
+					VisibleAppIDs:  []string{},
+				}, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	planVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, "some-uuid"),
+		"first_name":           tftypes.NewValue(tftypes.String, "John"),
+		"last_name":            tftypes.NewValue(tftypes.String, "Smith"),
+		"email":                tftypes.NewValue(tftypes.String, "jsmith@example.com"),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{tftypes.NewValue(tftypes.String, "DEVELOPER")}),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, true),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, false),
+	})
+
+	req := resource.UpdateRequest{
+		Plan:  tfsdk.Plan{Schema: schema, Raw: planVal},
+		State: tfsdk.State{Schema: schema, Raw: planVal},
+	}
+	resp := &resource.UpdateResponse{
+		State: tfsdk.State{Schema: schema, Raw: planVal},
+	}
+
+	r.Update(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+	}
+
+	var data UserResourceModel
+	resp.State.Get(context.Background(), &data)
+
+	if !data.VisibleApps.IsNull() {
+		t.Errorf("expected VisibleApps to be null when AllAppsVisible is true, got %v", data.VisibleApps)
+	}
+}
+
 func TestUserResource_Update_DoesNotSendReadOnlyFields(t *testing.T) {
 	var capturedUser users.User
 


### PR DESCRIPTION
## Problem

When switching a user from a subset of apps to all apps (`all_apps_visible = true`), the `Update` function was saving `VisibleApps` as an empty set `[]` in state rather than `null`. This caused a perpetual diff on every subsequent `terraform plan`, since the config has no `visible_apps` value (null) but state held `[]`.

## Fix

Replace the manual field assignments in `Update` with a call to `populateState`, making it consistent with `Read` which already handled this case correctly.

## Tests

Added `TestUserResource_Update_SetsVisibleAppsNullWhenAllAppsVisible` which fails before the fix and passes after.