### PR TITLE
fix: set visible_apps to null in Create when all_apps_visible is true

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# Copilot Instructions
+
+## Commands
+
+```shell
+make test          # run unit tests
+make testacc       # run acceptance tests (requires real App Store Connect credentials)
+make lint          # run golangci-lint
+make fmt           # format code with gofmt
+make generate      # regenerate docs (must be committed — CI checks for drift)
+make build         # compile the provider
+```
+
+Run a single test:
+```shell
+go test ./internal/provider/ -run TestUserResource_Update_SetsVisibleAppsNullWhenAllAppsVisible -v
+```
+
+## Architecture
+
+This is a [Terraform Plugin Framework](https://github.com/hashicorp/terraform-plugin-framework) provider. All provider logic lives in `internal/provider/`.
+
+The provider wraps the [`appstore-go`](https://github.com/oliver-binns/appstore-go) SDK client, which handles App Store Connect API authentication (JWT via `.p8` private key) and HTTP calls. The provider itself never calls the API directly.
+
+Currently one resource is implemented: `appstoreconnect_user` (`user_resource.go`). New resources follow the same pattern:
+- Implement `resource.Resource` (CRUD) + `resource.ResourceWithValidateConfig` + `resource.ResourceWithModifyPlan`
+- Register in `provider.go` → `Resources()`
+
+## Key Conventions
+
+### TDD is preferred
+Write a failing unit test before implementing a fix or feature. Unit tests in `*_unit_test.go` use `mockUserClient` and run without network access — prefer these for all logic and edge cases.
+
+### `populateState` is the single source of truth for API → state mapping
+After any API call (Create, Read, Update), always use `r.populateState(ctx, &data, user, resp.Diagnostics)` to write the response into state. Do **not** assign fields manually. This ensures special-case logic (e.g. setting `visible_apps` to null when `all_apps_visible` is true) is applied consistently everywhere.
+
+### Two test layers
+- `*_unit_test.go` — fast, no network, use `mockUserClient` to stub the API.
+- `*_test.go` — acceptance tests that hit real App Store Connect. Require `TF_ACC=1` and env vars `TF_VAR_issuer_id`, `TF_VAR_key_id`, `TF_VAR_private_key`.
+
+### `ValidateConfig` for mutually exclusive attributes
+Config-level validation (e.g. `all_apps_visible = true` must not be combined with `visible_apps`) lives in `ValidateConfig`, not in Create/Update.
+
+### `ModifyPlan` for forced replacement
+`ModifyPlan` detects when a user hasn't accepted their invite yet and marks all attributes as requiring replacement, with a warning diagnostic.
+
+### Conventional Commits required
+All PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) — this drives automated versioning. Enable the repo's Git hooks to catch this locally:
+```shell
+git config core.hooksPath hooks
+```

--- a/internal/provider/user_resource.go
+++ b/internal/provider/user_resource.go
@@ -220,19 +220,7 @@ func (r *UserResource) Create(ctx context.Context, req resource.CreateRequest, r
 
 	tflog.Trace(ctx, "created a new user")
 
-	data.ID = types.StringValue(user.ID)
-	data.FirstName = types.StringValue(user.FirstName)
-	data.LastName = types.StringValue(user.LastName)
-	data.Email = types.StringValue(user.Username)
-
-	data.Roles, diag = types.SetValueFrom(ctx, types.StringType, user.Roles)
-	resp.Diagnostics.Append(diag...)
-
-	data.VisibleApps, diag = types.SetValueFrom(ctx, types.StringType, user.VisibleAppIDs)
-	resp.Diagnostics.Append(diag...)
-
-	data.AllAppsVisible = types.BoolValue(user.AllAppsVisible)
-	data.ProvisioningAllowed = types.BoolValue(user.ProvisioningAllowed)
+	r.populateState(ctx, &data, user, resp.Diagnostics)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/provider/user_resource_unit_test.go
+++ b/internal/provider/user_resource_unit_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 type mockUserClient struct {
+	createUserFn      func(ctx context.Context, user users.User) (*users.User, error)
 	getUserFn         func(ctx context.Context, id string) (*users.User, error)
 	modifyUserFn      func(ctx context.Context, id string, user users.User) (*users.User, error)
 	findUserByEmailFn func(ctx context.Context, email string) (*users.User, error)
@@ -27,7 +28,10 @@ func (m *mockUserClient) GetUser(ctx context.Context, id string) (*users.User, e
 }
 
 func (m *mockUserClient) CreateUser(ctx context.Context, user users.User) (*users.User, error) {
-	return nil, nil
+	if m.createUserFn != nil {
+		return m.createUserFn(ctx, user)
+	}
+	return &users.User{}, nil
 }
 
 func (m *mockUserClient) ModifyUser(ctx context.Context, id string, user users.User) (*users.User, error) {
@@ -269,6 +273,52 @@ func TestPopulateState_SetsVisibleAppsFromAPIWhenNotAllAppsVisible(t *testing.T)
 	elements := data.VisibleApps.Elements()
 	if len(elements) != 2 {
 		t.Errorf("expected 2 visible app IDs, got %d", len(elements))
+	}
+}
+
+func TestUserResource_Create_SetsVisibleAppsNullWhenAllAppsVisible(t *testing.T) {
+	r := &UserResource{
+		client: &mockUserClient{
+			createUserFn: func(ctx context.Context, user users.User) (*users.User, error) {
+				return &users.User{
+					ID:             "new-uuid",
+					AllAppsVisible: true,
+					VisibleAppIDs:  []string{},
+				}, nil
+			},
+		},
+	}
+
+	schema := userResourceSchema()
+	planVal := tftypes.NewValue(schema.Type().TerraformType(context.Background()), map[string]tftypes.Value{
+		"id":                   tftypes.NewValue(tftypes.String, ""),
+		"first_name":           tftypes.NewValue(tftypes.String, "Jo"),
+		"last_name":            tftypes.NewValue(tftypes.String, "Dubey"),
+		"email":                tftypes.NewValue(tftypes.String, "jodubey@example.com"),
+		"roles":                tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, []tftypes.Value{tftypes.NewValue(tftypes.String, "DEVELOPER")}),
+		"all_apps_visible":     tftypes.NewValue(tftypes.Bool, true),
+		"visible_apps":         tftypes.NewValue(tftypes.Set{ElementType: tftypes.String}, nil),
+		"provisioning_allowed": tftypes.NewValue(tftypes.Bool, false),
+	})
+
+	req := resource.CreateRequest{
+		Plan: tfsdk.Plan{Schema: schema, Raw: planVal},
+	}
+	resp := &resource.CreateResponse{
+		State: tfsdk.State{Schema: schema, Raw: planVal},
+	}
+
+	r.Create(context.Background(), req, resp)
+
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected error: %s", resp.Diagnostics.Errors()[0].Detail())
+	}
+
+	var data UserResourceModel
+	resp.State.Get(context.Background(), &data)
+
+	if !data.VisibleApps.IsNull() {
+		t.Errorf("expected VisibleApps to be null when AllAppsVisible is true, got %v", data.VisibleApps)
 	}
 }
 


### PR DESCRIPTION
## Problem

Creating a user with `all_apps_visible = true` caused Terraform to throw:

```
produced an unexpected new value: .visible_apps: was null, but now cty.SetValEmpty(cty.String)
```

The `Create` function was manually assigning `VisibleApps` directly from the API response (an empty slice), rather than `null`. This mismatched the plan, which had no `visible_apps` set.

## Fix

Replace manual field assignments in `Create` with `populateState`, consistent with `Read` and the recent fix to `Update` in #37.

## Tests

Added `TestUserResource_Create_SetsVisibleAppsNullWhenAllAppsVisible`, which fails before the fix and passes after. Also added a `createUserFn` hook to `mockUserClient` to support stubbing `CreateUser` in unit tests.